### PR TITLE
feat: Add build script and publish a version for Deno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ typings/
 
 # Build folders
 lib/
+deno/
 *.sqlite

--- a/packages/hooks/.npmignore
+++ b/packages/hooks/.npmignore
@@ -1,2 +1,3 @@
 test/
 tsconfig.json
+build/

--- a/packages/hooks/build/deno.js
+++ b/packages/hooks/build/deno.js
@@ -1,0 +1,22 @@
+// A silly build script that converts the incompatible
+// TypeScript/Deno module references
+const path = require('path');
+const fs = require('fs');
+
+const moduleNames = [
+  './base', './compose', './decorator',
+  './function', './object'
+];
+
+const folder = path.join(__dirname, '..', 'src');
+const out = path.join(__dirname, '..', 'deno');
+
+for (const fileName of fs.readdirSync(folder)) {
+  const content = fs.readFileSync(path.join(folder, fileName)).toString();
+  const replacedContent = moduleNames.reduce((current, mod) =>
+    current.replace(new RegExp('\'' + mod + '\'', 'g'), `'${mod}.ts'`)
+  , content);
+
+  console.log(path.join(out, fileName))
+  fs.writeFileSync(path.join(out, fileName), replacedContent);
+}

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -27,8 +27,10 @@
   "main": "lib/",
   "types": "lib/",
   "scripts": {
-    "prepublish": "npm run compile",
+    "build:deno": "shx mkdir -p deno && node build/deno",
     "compile": "shx rm -rf lib/ && tsc",
+    "build": "npm run compile && npm run build:deno",
+    "prepublish": "npm run build",
     "test": "mocha --opts ../../mocha.opts --recursive test/**.test.ts test/**/*.test.ts"
   },
   "directories": {

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ To a function or class without having to change its original code while also kee
 
 - [@feathersjs/hooks](#feathersjshooks)
   - [Installation](#installation)
+    - [Node](#node)
+    - [Deno](#deno)
   - [Quick Example](#quick-example)
     - [JavaScript](#javascript)
     - [TypeScript](#typescript)
@@ -44,9 +46,20 @@ To a function or class without having to change its original code while also kee
 
 ## Installation
 
+### Node
+
 ```
 npm install @feathersjs/hooks --save
+yarn add @feathersjs/hooks
 ```
+
+### Deno
+
+```
+import { hooks } from 'https://unpkg.com/@feathersjs/hooks@latest/deno/index.ts';
+```
+
+> __Note:__ You might want to replace `latest` with the actual version you want to use (e.g. `https://unpkg.com/@feathersjs/hooks@0.2.0/deno/index.ts`)
 
 ## Quick Example
 


### PR DESCRIPTION
Since `@feathersjs/hooks` is written in TypeScript there is no reason for it to not work with [Deno](https://deno.land/) (a new JS/TypeScript runtime). Except that the TypeScript for Node and Deno module import syntax is not compatible. In order to import the module properly like

```
import { hooks } from 'https://unpkg.com/@feathersjs/hooks@0.1.0/deno/index.ts';
```

We need to rewrite the module names to add the `.ts` extension (which for not so great reasons gives a compiler error in normal TypeScript).