### PR TITLE
fix(hooks): Allow to set context.result to undefined

### DIFF
--- a/packages/hooks/src/hooks.ts
+++ b/packages/hooks/src/hooks.ts
@@ -37,7 +37,7 @@ export function functionHooks <F> (fn: F, managerOrMiddleware: HookOptions) {
 
     // Runs the actual original method if `ctx.result` is not already set
     hookChain.push((ctx, next) => {
-      if (!Object.hasOwnProperty.call(context, 'result')) {
+      if (!Object.prototype.hasOwnProperty.call(context, 'result')) {
         return Promise.resolve(original.apply(this, ctx.arguments)).then(result => {
           ctx.result = result;
 

--- a/packages/hooks/src/hooks.ts
+++ b/packages/hooks/src/hooks.ts
@@ -37,7 +37,7 @@ export function functionHooks <F> (fn: F, managerOrMiddleware: HookOptions) {
 
     // Runs the actual original method if `ctx.result` is not already set
     hookChain.push((ctx, next) => {
-      if (Object.getOwnPropertyDescriptor(context, 'result') === undefined) {
+      if (!Object.hasOwnProperty.call(context, 'result')) {
         return Promise.resolve(original.apply(this, ctx.arguments)).then(result => {
           ctx.result = result;
 

--- a/packages/hooks/src/hooks.ts
+++ b/packages/hooks/src/hooks.ts
@@ -37,7 +37,7 @@ export function functionHooks <F> (fn: F, managerOrMiddleware: HookOptions) {
 
     // Runs the actual original method if `ctx.result` is not already set
     hookChain.push((ctx, next) => {
-      if (ctx.result === undefined) {
+      if (Object.getOwnPropertyDescriptor(context, 'result') === undefined) {
         return Promise.resolve(original.apply(this, ctx.arguments)).then(result => {
           ctx.result = result;
 

--- a/packages/hooks/test/function.test.ts
+++ b/packages/hooks/test/function.test.ts
@@ -86,6 +86,30 @@ describe('functionHooks', () => {
     assert.strictEqual(res, undefined);
   });
 
+  it('deleting context.result, does not skip method call', async () => {
+    const hello = async (name: string) => {
+      return name;
+    };
+    const updateResult = async (ctx: HookContext, next: NextFunction) => {
+      ctx.result = 'Dave';
+
+      await next();
+    };
+    const deleteResult = async (ctx: HookContext, next: NextFunction) => {
+      delete ctx.result;
+
+      await next();
+    };
+
+    const fn = hooks(hello, middleware([
+      updateResult,
+      deleteResult
+    ]));
+    const res = await fn('There');
+
+    assert.strictEqual(res, 'There');
+  });
+
   it('can override context.result after', async () => {
     const updateResult = async (ctx: HookContext, next: NextFunction) => {
       await next();

--- a/packages/hooks/test/function.test.ts
+++ b/packages/hooks/test/function.test.ts
@@ -70,6 +70,22 @@ describe('functionHooks', () => {
     assert.strictEqual(res, 'Hello Dave');
   });
 
+  it('can set context.result to undefined, skips method call, returns undefined', async () => {
+    const hello = async (_name: string) => {
+      throw new Error('Should never get here');
+    };
+    const updateResult = async (ctx: HookContext, next: NextFunction) => {
+      ctx.result = undefined;
+
+      await next();
+    };
+
+    const fn = hooks(hello, middleware([ updateResult ]));
+    const res = await fn('There');
+
+    assert.strictEqual(res, undefined);
+  });
+
   it('can override context.result after', async () => {
     const updateResult = async (ctx: HookContext, next: NextFunction) => {
       await next();


### PR DESCRIPTION
This pull request allows to set `context.result` to `undefined` in a before hook as suggested by @vonagam. It should be fully backwards compatible.

Closes https://github.com/feathersjs/hooks/issues/69