### PR TITLE
chore(tests): replace equal by strictEqual

### DIFF
--- a/packages/hooks/test/benchmark.test.ts
+++ b/packages/hooks/test/benchmark.test.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import * as assert from 'assert';
 import { hooks, HookContext, NextFunction, middleware } from '../src/';
 
 const CYCLES = 100000;

--- a/packages/hooks/test/class.test.ts
+++ b/packages/hooks/test/class.test.ts
@@ -91,7 +91,7 @@ describe('class objectHooks', () => {
     hooks(DummyClass, {
       sayHi: middleware([
         async (ctx, next) => {
-          assert.equal(ctx.name, 'Dave');
+          assert.strictEqual(ctx.name, 'Dave');
 
           ctx.name = 'Changed';
 
@@ -106,8 +106,8 @@ describe('class objectHooks', () => {
     hooks(OtherDummy, {
       sayHi: middleware([
         async (ctx, next) => {
-          assert.equal(ctx.name, 'Changed');
-          assert.equal(ctx.gna, 42);
+          assert.strictEqual(ctx.name, 'Changed');
+          assert.strictEqual(ctx.gna, 42);
 
           await next();
         }
@@ -119,15 +119,15 @@ describe('class objectHooks', () => {
     hooks(instance, {
       sayHi: middleware([
         async (ctx, next) => {
-          assert.equal(ctx.name, 'Changed');
-          assert.equal(ctx.gna, 42);
-          assert.equal(ctx.app, 'ok');
+          assert.strictEqual(ctx.name, 'Changed');
+          assert.strictEqual(ctx.gna, 42);
+          assert.strictEqual(ctx.app, 'ok');
 
           await next();
         }
       ]).props({ app: 'ok' })
     });
 
-    assert.equal(await instance.sayHi('Dave'), 'Hi Changed');
+    assert.strictEqual(await instance.sayHi('Dave'), 'Hi Changed');
   });
 });

--- a/packages/hooks/test/class.test.ts
+++ b/packages/hooks/test/class.test.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import * as assert from 'assert';
 import { hooks, middleware, HookContext, NextFunction } from '../src';
 
 interface Dummy {

--- a/packages/hooks/test/compose.test.ts
+++ b/packages/hooks/test/compose.test.ts
@@ -103,7 +103,7 @@ describe('Koa Compose', function () {
     compose(stack)({});
 
     for (const next of arr) {
-      assert(isPromise(next), 'one of the functions next is not a Promise');
+      assert.ok(isPromise(next), 'one of the functions next is not a Promise');
     }
   });
 
@@ -128,7 +128,7 @@ describe('Koa Compose', function () {
     });
 
     await compose(stack)({});
-    assert(called);
+    assert.ok(called);
   });
 
   it('should reject on errors in middleware', () => {
@@ -209,7 +209,7 @@ describe('Koa Compose', function () {
     return compose([])({}, async () => {
       called = true;
     }).then(function () {
-      assert(called);
+      assert.ok(called);
     });
   });
 
@@ -258,7 +258,7 @@ describe('Koa Compose', function () {
     ])({}).then(() => {
       throw new Error('boom');
     }, (err) => {
-      assert(/multiple times/.test(err.message));
+      assert.ok(/multiple times/.test(err.message));
     });
   });
 

--- a/packages/hooks/test/compose.test.ts
+++ b/packages/hooks/test/compose.test.ts
@@ -1,5 +1,5 @@
 // Adapted from koa-compose (https://github.com/koajs/compose)
-import { strict as assert } from 'assert';
+import * as assert from 'assert';
 import { compose, NextFunction } from '../src';
 
 function wait (ms: number) {

--- a/packages/hooks/test/compose.test.ts
+++ b/packages/hooks/test/compose.test.ts
@@ -280,7 +280,7 @@ describe('Koa Compose', function () {
         return next();
       }
     ])({}).then(function () {
-      assert.equal(val, 3);
+      assert.strictEqual(val, 3);
     });
   });
 
@@ -289,20 +289,20 @@ describe('Koa Compose', function () {
 
     stack.push(async (_context: any, next: NextFunction) => {
       const val = await next();
-      assert.equal(val, 2);
+      assert.strictEqual(val, 2);
       return 1;
     });
 
     stack.push(async (_context: any, next: NextFunction) => {
       const val = await next();
-      assert.equal(val, 0);
+      assert.strictEqual(val, 0);
       return 2;
     });
 
     const next = async () => 0;
 
     return compose(stack)({}, next).then(function (val) {
-      assert.equal(val, 1);
+      assert.strictEqual(val, 1);
     });
   });
 
@@ -314,13 +314,13 @@ describe('Koa Compose', function () {
     middleware.push(fn1);
 
     for (const fn of middleware) {
-      assert.equal(fn, fn1);
+      assert.strictEqual(fn, fn1);
     }
 
     compose(middleware);
 
     for (const fn of middleware) {
-      assert.equal(fn, fn1);
+      assert.strictEqual(fn, fn1);
     }
   });
 

--- a/packages/hooks/test/decorator.test.ts
+++ b/packages/hooks/test/decorator.test.ts
@@ -26,7 +26,7 @@ describe('hookDecorator', () => {
     class DummyClass extends TopLevel {
       @hooks(middleware([
         async (ctx: HookContext, next: NextFunction) => {
-          assert.equal(ctx.method, 'sayHi');
+          assert.strictEqual(ctx.method, 'sayHi');
           assert.deepEqual(ctx.arguments, [expectedName]);
           assert.deepEqual(ctx.name, expectedName);
 

--- a/packages/hooks/test/decorator.test.ts
+++ b/packages/hooks/test/decorator.test.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import * as assert from 'assert';
 import { hooks, HookContext, NextFunction, middleware } from '../src';
 
 describe('hookDecorator', () => {

--- a/packages/hooks/test/function.test.ts
+++ b/packages/hooks/test/function.test.ts
@@ -18,7 +18,7 @@ describe('functionHooks', () => {
     const fn = hooks(hello, []);
 
     assert.notDeepEqual(fn, hello);
-    assert.ok(getManager(fn) !== null);
+    assert.notStrictEqual(getManager(fn), null);
   });
 
   it('throws an error with non function', () => {

--- a/packages/hooks/test/function.test.ts
+++ b/packages/hooks/test/function.test.ts
@@ -49,9 +49,9 @@ describe('functionHooks', () => {
       }
     ]));
 
-    assert.equal(typeof fn.original, 'function');
+    assert.strictEqual(typeof fn.original, 'function');
 
-    assert.equal(await fn.original('Dave'), 'Hello Dave');
+    assert.strictEqual(await fn.original('Dave'), 'Hello Dave');
   });
 
   it('can override context.result before, skips method call', async () => {
@@ -213,13 +213,13 @@ describe('functionHooks', () => {
 
     const result = await second('Dave');
 
-    assert.equal(result, 'Hello Dave test value');
+    assert.strictEqual(result, 'Hello Dave test value');
   });
 
   it('creates context with params and converts to arguments', async () => {
     const fn = hooks(hello, middleware([
       async (ctx, next) => {
-        assert.equal(ctx.name, 'Dave');
+        assert.strictEqual(ctx.name, 'Dave');
 
         ctx.name = 'Changed';
 
@@ -227,14 +227,14 @@ describe('functionHooks', () => {
       }
     ]).params('name'));
 
-    assert.equal(await fn('Dave'), 'Hello Changed');
+    assert.strictEqual(await fn('Dave'), 'Hello Changed');
   });
 
   it('assigns props to context', async () => {
     const fn = hooks(hello, middleware([
       async (ctx, next) => {
-        assert.equal(ctx.name, 'Dave');
-        assert.equal(ctx.dev, true);
+        assert.strictEqual(ctx.name, 'Dave');
+        assert.strictEqual(ctx.dev, true);
 
         ctx.name = 'Changed';
 
@@ -242,14 +242,14 @@ describe('functionHooks', () => {
       }
     ]).params('name').props({ dev: true }));
 
-    assert.equal(await fn('Dave'), 'Hello Changed');
+    assert.strictEqual(await fn('Dave'), 'Hello Changed');
   });
 
   it('assigns props to context by options', async () => {
     const fn = hooks(hello, middleware([
       async (ctx, next) => {
-        assert.equal(ctx.name, 'Dave');
-        assert.equal(ctx.dev, true);
+        assert.strictEqual(ctx.name, 'Dave');
+        assert.strictEqual(ctx.dev, true);
 
         ctx.name = 'Changed';
 
@@ -260,7 +260,7 @@ describe('functionHooks', () => {
       props: { dev: true }
     }));
 
-    assert.equal(await fn('Dave'), 'Hello Changed');
+    assert.strictEqual(await fn('Dave'), 'Hello Changed');
   });
 
   it('ctx.arguments is configurable with named params', async () => {
@@ -268,7 +268,7 @@ describe('functionHooks', () => {
       ctx.arguments[0] = 'Changed';
       ctx.arguments.push('no');
 
-      assert.equal(ctx.name, ctx.arguments[0]);
+      assert.strictEqual(ctx.name, ctx.arguments[0]);
 
       await next();
     };
@@ -278,7 +278,7 @@ describe('functionHooks', () => {
     const customContext = fn.createContext();
     const resultContext = await fn('Daffl', {}, customContext);
 
-    assert.equal(resultContext, customContext);
+    assert.strictEqual(resultContext, customContext);
     assert.deepEqual(resultContext, fn.createContext({
       arguments: ['Changed', {}, 'no'],
       name: 'Changed',
@@ -290,8 +290,8 @@ describe('functionHooks', () => {
     const message = 'Custom message';
     const fn = hooks(hello, middleware([
       async (ctx, next) => {
-        assert.equal(ctx.name, 'Dave');
-        assert.equal(ctx.message, message);
+        assert.strictEqual(ctx.name, 'Dave');
+        assert.strictEqual(ctx.message, message);
 
         ctx.name = 'Changed';
         await next();
@@ -301,7 +301,7 @@ describe('functionHooks', () => {
     const customContext = fn.createContext({ message });
     const resultContext: HookContext = await fn('Dave', {}, customContext);
 
-    assert.equal(resultContext, customContext);
+    assert.strictEqual(resultContext, customContext);
     assert.deepEqual(resultContext, fn.createContext({
       arguments: ['Changed', {}],
       message: 'Custom message',
@@ -329,8 +329,8 @@ describe('functionHooks', () => {
 
     const result = await exclamation('Bertho');
 
-    assert.equal(result, 'Hi Bertho!');
-    assert.equal(called, 1);
+    assert.strictEqual(result, 'Hi Bertho!');
+    assert.strictEqual(called, 1);
   });
 
   it('conserves method properties', async () => {
@@ -347,8 +347,8 @@ describe('functionHooks', () => {
 
     const result = await sayHi('Bertho');
 
-    assert.equal(result, 'Hi Bertho!');
-    assert.equal((sayHi as any)[TEST], (hello as any)[TEST]);
+    assert.strictEqual(result, 'Hi Bertho!');
+    assert.strictEqual((sayHi as any)[TEST], (hello as any)[TEST]);
   });
 
   it('works with array as middleware', async () => {
@@ -365,8 +365,8 @@ describe('functionHooks', () => {
 
     const result = await sayHi('Bertho');
 
-    assert.equal(result, 'Hi Bertho!');
-    assert.equal((sayHi as any)[TEST], (hello as any)[TEST]);
+    assert.strictEqual(result, 'Hi Bertho!');
+    assert.strictEqual((sayHi as any)[TEST], (hello as any)[TEST]);
   });
 
   it('context has own properties', async () => {
@@ -401,7 +401,7 @@ describe('functionHooks', () => {
       })
     );
 
-    assert.equal(await fn('Dave'), 'Hello Dave');
-    assert.equal(await fn(), 'Hello Bertho');
+    assert.strictEqual(await fn('Dave'), 'Hello Dave');
+    assert.strictEqual(await fn(), 'Hello Bertho');
   });
 });

--- a/packages/hooks/test/function.test.ts
+++ b/packages/hooks/test/function.test.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import * as assert from 'assert';
 import {
   hooks,
   middleware,

--- a/packages/hooks/test/object.test.ts
+++ b/packages/hooks/test/object.test.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'assert';
+import * as assert from 'assert';
 import { hooks, middleware, HookContext, NextFunction } from '../src';
 
 interface HookableObject {

--- a/packages/hooks/test/object.test.ts
+++ b/packages/hooks/test/object.test.ts
@@ -27,7 +27,7 @@ describe('objectHooks', () => {
   it('hooks object with hook methods, sets method name', async () => {
     const hookedObj = hooks(obj, {
       sayHi: middleware([async (ctx: HookContext, next: NextFunction) => {
-        assert.equal(ctx.method, 'sayHi');
+        assert.strictEqual(ctx.method, 'sayHi');
         assert.deepEqual(ctx, new (obj.sayHi as any).Context({
           arguments: [ 'David' ],
           method: 'sayHi',
@@ -129,6 +129,6 @@ describe('objectHooks', () => {
       }])
     });
 
-    assert.equal(await obj.sayHi('Dave'), 'Hi Dave?!');
+    assert.strictEqual(await obj.sayHi('Dave'), 'Hi Dave?!');
   });
 });


### PR DESCRIPTION
`assert.equal` is deprecated in favor of `assert.strictEqual`, I also replaced a `assert.ok` by a `assert.notStrictEqual`

![image](https://user-images.githubusercontent.com/8525267/114076935-88fa5680-98a7-11eb-842b-c1b5cb41fbc3.png)