### PR TITLE
fix(typescript): Tighten up TypeScript settings to be ECMAScript and Deno compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,241 +4,315 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.10.4"
+				"@babel/highlight": "^7.12.13"
 			}
 		},
+		"@babel/compat-data": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+			"integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==",
+			"dev": true
+		},
 		"@babel/core": {
-			"version": "7.12.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
-			"integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+			"integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.1",
-				"@babel/helper-module-transforms": "^7.12.1",
-				"@babel/helpers": "^7.12.1",
-				"@babel/parser": "^7.12.3",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.1",
-				"@babel/types": "^7.12.1",
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.13.16",
+				"@babel/helper-compilation-targets": "^7.13.16",
+				"@babel/helper-module-transforms": "^7.13.14",
+				"@babel/helpers": "^7.13.16",
+				"@babel/parser": "^7.13.16",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.15",
+				"@babel/types": "^7.13.16",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.1",
+				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.19",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
+				"semver": "^6.3.0",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 					"dev": true
 				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-			"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
+			"integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.5",
+				"@babel/types": "^7.13.16",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+			"integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.13.15",
+				"@babel/helper-validator-option": "^7.12.17",
+				"browserslist": "^4.14.5",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/helper-get-function-arity": "^7.12.13",
+				"@babel/template": "^7.12.13",
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+			"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-			"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+			"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.1"
+				"@babel/types": "^7.13.12"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+			"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.5"
+				"@babel/types": "^7.13.12"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+			"version": "7.13.14",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+			"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.12.1",
-				"@babel/helper-replace-supers": "^7.12.1",
-				"@babel/helper-simple-access": "^7.12.1",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.1",
-				"@babel/types": "^7.12.1",
-				"lodash": "^4.17.19"
+				"@babel/helper-module-imports": "^7.13.12",
+				"@babel/helper-replace-supers": "^7.13.12",
+				"@babel/helper-simple-access": "^7.13.12",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.13",
+				"@babel/types": "^7.13.14"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+			"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-			"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+			"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.12.1",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/traverse": "^7.12.5",
-				"@babel/types": "^7.12.5"
+				"@babel/helper-member-expression-to-functions": "^7.13.12",
+				"@babel/helper-optimise-call-expression": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.12"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+			"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.1"
+				"@babel/types": "^7.13.12"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+			"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+			"dev": true
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.17",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
 			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
-			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.16.tgz",
+			"integrity": "sha512-x5otxUaLpdWHl02P4L94wBU+2BJXBkvO+6d6uzQ+xD9/h2hTSAwA5O8QV8GqKx/l8i+VYmKKQg9e2QGTa2Wu3Q==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.5",
-				"@babel/types": "^7.12.5"
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.15",
+				"@babel/types": "^7.13.16"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"version": "7.13.10",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+			"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.12.11",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
-			}
-		},
-		"@babel/parser": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-			"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
-			"dev": true
-		},
-		"@babel/template": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-			"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.5",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.5",
-				"@babel/types": "^7.12.5",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"ms": "2.1.2"
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
-		"@babel/types": {
-			"version": "7.12.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-			"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+		"@babel/parser": {
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+			"integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
+			"dev": true
+		},
+		"@babel/template": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+			"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"lodash": "^4.17.19",
+				"@babel/code-frame": "^7.12.13",
+				"@babel/parser": "^7.12.13",
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+			"integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.13.9",
+				"@babel/helper-function-name": "^7.12.13",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/parser": "^7.13.15",
+				"@babel/types": "^7.13.14",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			}
+		},
+		"@babel/types": {
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.16.tgz",
+			"integrity": "sha512-7enM8Wxhrl1hB1+k6+xO6RmxpNkaveRWkdpyii8DkrLWRgr0l3x29/SEuhTIkP+ynHsU/Hpjn8Evd/axv/ll6Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.12.11",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -253,54 +327,12 @@
 				"get-package-type": "^0.1.0",
 				"js-yaml": "^3.13.1",
 				"resolve-from": "^5.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
-				}
 			}
 		},
 		"@istanbuljs/schema": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
-			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
 			"dev": true
 		},
 		"@lerna/add": {
@@ -319,17 +351,6 @@
 				"p-map": "^4.0.0",
 				"pacote": "^11.2.6",
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/bootstrap": {
@@ -360,17 +381,6 @@
 				"p-waterfall": "^2.1.1",
 				"read-package-tree": "^5.3.1",
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/changed": {
@@ -405,57 +415,6 @@
 				"chalk": "^4.1.0",
 				"execa": "^5.0.0",
 				"strong-log-transformer": "^2.1.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/clean": {
@@ -495,57 +454,6 @@
 				"@lerna/child-process": "4.0.0",
 				"chalk": "^4.1.0",
 				"npmlog": "^4.1.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/collect-updates": {
@@ -603,15 +511,6 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
 					"integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
 					"dev": true
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
 				}
 			}
 		},
@@ -646,15 +545,6 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
 					"integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
 					"dev": true
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
 				},
 				"yargs-parser": {
 					"version": "20.2.4",
@@ -849,17 +739,6 @@
 			"requires": {
 				"@lerna/child-process": "4.0.0",
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/import": {
@@ -936,57 +815,6 @@
 				"@lerna/query-graph": "4.0.0",
 				"chalk": "^4.1.0",
 				"columnify": "^1.5.4"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/log-packed": {
@@ -1063,14 +891,14 @@
 			},
 			"dependencies": {
 				"normalize-package-data": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-					"integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^3.0.6",
-						"resolve": "^1.17.0",
-						"semver": "^7.3.2",
+						"hosted-git-info": "^4.0.1",
+						"resolve": "^1.20.0",
+						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
 				},
@@ -1090,15 +918,6 @@
 						"json-parse-even-better-errors": "^2.3.0",
 						"normalize-package-data": "^3.0.0",
 						"npm-normalize-package-bin": "^1.0.0"
-					}
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
 					}
 				}
 			}
@@ -1225,17 +1044,6 @@
 				"npm-package-arg": "^8.1.0",
 				"npmlog": "^4.1.2",
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/prerelease-id-from-version": {
@@ -1245,17 +1053,6 @@
 			"dev": true,
 			"requires": {
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/profiler": {
@@ -1333,17 +1130,6 @@
 				"p-pipe": "^3.1.0",
 				"pacote": "^11.2.6",
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/pulse-till-done": {
@@ -1498,66 +1284,6 @@
 				"slash": "^3.0.0",
 				"temp-write": "^4.0.0",
 				"write-json-file": "^4.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"@lerna/write-log-file": {
@@ -1617,19 +1343,18 @@
 			"dev": true
 		},
 		"@npmcli/git": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.0.6.tgz",
-			"integrity": "sha512-a1MnTfeRPBaKbFY07fd+6HugY1WAkKJzdiJvlRub/9o5xz2F/JtPacZZapx5zRJUQFIzSL677vmTSxEcDMrDbg==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.0.8.tgz",
+			"integrity": "sha512-LPnzyBZ+1p7+JzHVwwKycMF8M3lr1ze3wxGRnxn/QxJtk++Y3prSJQrdBDGCxJyRpFsup6J3lrRBVYBhJVrM8Q==",
 			"dev": true,
 			"requires": {
-				"@npmcli/promise-spawn": "^1.1.0",
+				"@npmcli/promise-spawn": "^1.3.2",
 				"lru-cache": "^6.0.0",
-				"mkdirp": "^1.0.3",
-				"npm-pick-manifest": "^6.0.0",
+				"mkdirp": "^1.0.4",
+				"npm-pick-manifest": "^6.1.1",
 				"promise-inflight": "^1.0.1",
 				"promise-retry": "^2.0.1",
-				"semver": "^7.3.2",
-				"unique-filename": "^1.1.1",
+				"semver": "^7.3.5",
 				"which": "^2.0.2"
 			},
 			"dependencies": {
@@ -1638,15 +1363,6 @@
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 					"dev": true
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
 				}
 			}
 		},
@@ -1694,16 +1410,15 @@
 			}
 		},
 		"@npmcli/run-script": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.3.tgz",
-			"integrity": "sha512-ELPGWAVU/xyU+A+H3pEPj0QOvYwLTX71RArXcClFzeiyJ/b/McsZ+d0QxpznvfFtZzxGN/gz/1cvlqICR4/suQ==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.4.tgz",
+			"integrity": "sha512-Yd9HXTtF1JGDXZw0+SOn+mWLYS0e7bHBHVC/2C8yqs4wUrs/k8rwBSinD7rfk+3WG/MFGRZKxjyoD34Pch2E/A==",
 			"dev": true,
 			"requires": {
 				"@npmcli/node-gyp": "^1.0.2",
 				"@npmcli/promise-spawn": "^1.3.2",
 				"infer-owner": "^1.0.4",
 				"node-gyp": "^7.1.0",
-				"puka": "^1.0.1",
 				"read-package-json-fast": "^2.0.1"
 			},
 			"dependencies": {
@@ -1774,15 +1489,6 @@
 						"abbrev": "1"
 					}
 				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
 				"tar": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
@@ -1809,16 +1515,17 @@
 			}
 		},
 		"@octokit/core": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.5.tgz",
-			"integrity": "sha512-+DCtPykGnvXKWWQI0E1XD+CCeWSBhB6kwItXqfFmNBlIlhczuDPbg+P6BtLnVBaRJDAjv+1mrUJuRsFSjktopg==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+			"integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
 			"dev": true,
 			"requires": {
 				"@octokit/auth-token": "^2.4.4",
 				"@octokit/graphql": "^4.5.8",
 				"@octokit/request": "^5.4.12",
+				"@octokit/request-error": "^2.0.5",
 				"@octokit/types": "^6.0.3",
-				"before-after-hook": "^2.1.0",
+				"before-after-hook": "^2.2.0",
 				"universal-user-agent": "^6.0.0"
 			}
 		},
@@ -1842,9 +1549,9 @@
 			}
 		},
 		"@octokit/graphql": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.0.tgz",
-			"integrity": "sha512-CJ6n7izLFXLvPZaWzCQDjU/RP+vHiZmWdOunaCS87v+2jxMsW9FB5ktfIxybRBxZjxuJGRnxk7xJecWTVxFUYQ==",
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
+			"integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
 			"dev": true,
 			"requires": {
 				"@octokit/request": "^5.3.0",
@@ -1853,9 +1560,9 @@
 			}
 		},
 		"@octokit/openapi-types": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.3.1.tgz",
-			"integrity": "sha512-TvVk2QuIA0lQZcIMd6xbdGaGDVeNYIOa3l1ZVagAIk5K3t/WMYbcg4BISNDhzdVhm/TgQB26frAgd/GV81aHJA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
+			"integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ==",
 			"dev": true
 		},
 		"@octokit/plugin-enterprise-rest": {
@@ -1865,9 +1572,9 @@
 			"dev": true
 		},
 		"@octokit/plugin-paginate-rest": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.11.0.tgz",
-			"integrity": "sha512-7L9xQank2G3r1dGqrVPo1z62V5utbykOUzlmNHPz87Pww/JpZQ9KyG5CHtUzgmB4n5iDRKYNK/86A8D98HP0yA==",
+			"version": "2.13.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+			"integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^6.11.0"
@@ -1880,28 +1587,26 @@
 			"dev": true
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
-			"version": "4.13.4",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.13.4.tgz",
-			"integrity": "sha512-MGxptzVfiP8O+aydC/riheYzS/yJ9P16M29OuvtZep/sF5sKuOCQP8Wf83YCKXRsQF+ZpYfke2snbPPSIMZKzg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
+			"integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^6.12.0",
+				"@octokit/types": "^6.13.0",
 				"deprecation": "^2.3.1"
 			}
 		},
 		"@octokit/request": {
-			"version": "5.4.14",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.14.tgz",
-			"integrity": "sha512-VkmtacOIQp9daSnBmDI92xNIeLuSRDOIuplp/CJomkvzt7M18NXgG044Cx/LFKLgjKt9T2tZR6AtJayba9GTSA==",
+			"version": "5.4.15",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
+			"integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.0.0",
 				"@octokit/types": "^6.7.1",
-				"deprecation": "^2.0.0",
 				"is-plain-object": "^5.0.0",
 				"node-fetch": "^2.6.1",
-				"once": "^1.4.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
@@ -1925,24 +1630,24 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "18.3.4",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.3.4.tgz",
-			"integrity": "sha512-NES0pHbwyFB1D0jrLkdnIXgEmze/gLE0JoSNgfAe4vwD77/qaQGO/lRWNuPPsoBVBjiW6mmA9CU5cYHujJTKQA==",
+			"version": "18.5.2",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
+			"integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
 			"dev": true,
 			"requires": {
 				"@octokit/core": "^3.2.3",
 				"@octokit/plugin-paginate-rest": "^2.6.2",
 				"@octokit/plugin-request-log": "^1.0.2",
-				"@octokit/plugin-rest-endpoint-methods": "4.13.4"
+				"@octokit/plugin-rest-endpoint-methods": "5.0.0"
 			}
 		},
 		"@octokit/types": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.12.1.tgz",
-			"integrity": "sha512-eZTTWJxGBon01Ra4EX86rvlMZGkU5SeJ8BtwQlsv2wEqZttpjtefLetJndZTVbJ25qFKoyKMWsRFnwlOx7ZaDQ==",
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+			"integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
 			"dev": true,
 			"requires": {
-				"@octokit/openapi-types": "^5.3.1"
+				"@octokit/openapi-types": "^6.0.0"
 			}
 		},
 		"@tootallnate/once": {
@@ -1952,9 +1657,9 @@
 			"dev": true
 		},
 		"@types/minimatch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
 			"dev": true
 		},
 		"@types/minimist": {
@@ -2040,18 +1745,18 @@
 			}
 		},
 		"ansi-escapes": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
 			"dev": true,
 			"requires": {
-				"type-fest": "^0.11.0"
+				"type-fest": "^0.21.3"
 			},
 			"dependencies": {
 				"type-fest": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 					"dev": true
 				}
 			}
@@ -2063,12 +1768,12 @@
 			"dev": true
 		},
 		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "^2.0.1"
 			}
 		},
 		"append-transform": {
@@ -2187,9 +1892,9 @@
 			"dev": true
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -2202,9 +1907,9 @@
 			}
 		},
 		"before-after-hook": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.0.tgz",
-			"integrity": "sha512-jH6rKQIfroBbhEXVmI7XmXe3ix5S/PgJqpzdDPnR8JGLHWNYLsYZ6tK5iWOF/Ra3oqEX0NobXGlzbiylIzVphQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
+			"integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -2224,6 +1929,19 @@
 			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
+			}
+		},
+		"browserslist": {
+			"version": "4.16.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+			"integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
+			"dev": true,
+			"requires": {
+				"caniuse-lite": "^1.0.30001208",
+				"colorette": "^1.2.2",
+				"electron-to-chromium": "^1.3.712",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.71"
 			}
 		},
 		"buffer-from": {
@@ -2257,9 +1975,9 @@
 			"dev": true
 		},
 		"cacache": {
-			"version": "15.0.5",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
-			"integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
+			"version": "15.0.6",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.6.tgz",
+			"integrity": "sha512-g1WYDMct/jzW+JdWEyjaX2zoBkZ6ZT9VpOyp2I/VMtDsNLffNat3kqPFfi1eDRSK9/SuKGyORDHcQMcPF8sQ/w==",
 			"dev": true,
 			"requires": {
 				"@npmcli/move-file": "^1.0.1",
@@ -2276,7 +1994,7 @@
 				"p-map": "^4.0.0",
 				"promise-inflight": "^1.0.1",
 				"rimraf": "^3.0.2",
-				"ssri": "^8.0.0",
+				"ssri": "^8.0.1",
 				"tar": "^6.0.2",
 				"unique-filename": "^1.1.1"
 			},
@@ -2358,6 +2076,12 @@
 						"semver": "^6.0.0"
 					}
 				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
 				"write-file-atomic": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -2405,6 +2129,12 @@
 				"quick-lru": "^4.0.1"
 			}
 		},
+		"caniuse-lite": {
+			"version": "1.0.30001214",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
+			"integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==",
+			"dev": true
+		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -2412,14 +2142,13 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
 			}
 		},
 		"chardet": {
@@ -2539,18 +2268,24 @@
 			"dev": true
 		},
 		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "~1.1.4"
 			}
 		},
 		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"colorette": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
 			"dev": true
 		},
 		"columnify": {
@@ -2686,24 +2421,15 @@
 			},
 			"dependencies": {
 				"normalize-package-data": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-					"integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^3.0.6",
-						"resolve": "^1.17.0",
-						"semver": "^7.3.2",
+						"hosted-git-info": "^4.0.1",
+						"resolve": "^1.20.0",
+						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
 					}
 				}
 			}
@@ -2730,6 +2456,14 @@
 				"semver": "^6.0.0",
 				"split": "^1.0.0",
 				"through2": "^4.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"conventional-commits-filter": {
@@ -2780,14 +2514,6 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
-				}
 			}
 		},
 		"core-util-is": {
@@ -2908,14 +2634,6 @@
 			"dev": true,
 			"requires": {
 				"strip-bom": "^4.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-					"dev": true
-				}
 			}
 		},
 		"defaults": {
@@ -3016,6 +2734,12 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"electron-to-chromium": {
+			"version": "1.3.717",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
+			"integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
+			"dev": true
+		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3033,15 +2757,15 @@
 			}
 		},
 		"env-paths": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
 			"dev": true
 		},
 		"envinfo": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.4.tgz",
-			"integrity": "sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
 			"dev": true
 		},
 		"err-code": {
@@ -3245,25 +2969,6 @@
 				"pkg-dir": "^4.1.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
 				"make-dir": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3273,29 +2978,11 @@
 						"semver": "^6.0.0"
 					}
 				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -3317,49 +3004,6 @@
 			"requires": {
 				"cross-spawn": "^7.0.0",
 				"signal-exit": "^3.0.2"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
 			}
 		},
 		"forever-agent": {
@@ -3503,9 +3147,9 @@
 					}
 				},
 				"hosted-git-info": {
-					"version": "2.8.8",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-					"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+					"version": "2.8.9",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+					"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 					"dev": true
 				},
 				"indent-string": {
@@ -3669,9 +3313,9 @@
 			"dev": true
 		},
 		"get-stream": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-			"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true
 		},
 		"getpass": {
@@ -3722,6 +3366,14 @@
 			"requires": {
 				"meow": "^8.0.0",
 				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"git-up": {
@@ -3782,9 +3434,9 @@
 			"dev": true
 		},
 		"globby": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-			"integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+			"integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
 			"dev": true,
 			"requires": {
 				"array-union": "^2.1.0",
@@ -3796,9 +3448,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
 			"dev": true
 		},
 		"handlebars": {
@@ -3812,14 +3464,6 @@
 				"source-map": "^0.6.1",
 				"uglify-js": "^3.1.4",
 				"wordwrap": "^1.0.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"har-schema": {
@@ -3860,9 +3504,9 @@
 			"dev": true
 		},
 		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true
 		},
 		"has-symbols": {
@@ -3887,12 +3531,6 @@
 				"type-fest": "^0.8.0"
 			},
 			"dependencies": {
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-					"dev": true
-				},
 				"type-fest": {
 					"version": "0.8.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -3902,9 +3540,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
-			"integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+			"integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
 			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"
@@ -4063,30 +3701,30 @@
 			"dev": true
 		},
 		"init-package-json": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-2.0.2.tgz",
-			"integrity": "sha512-PO64kVeArePvhX7Ff0jVWkpnE1DfGRvaWcStYrPugcJz9twQGYibagKJuIMHCX7ENcp0M6LJlcjLBuLD5KeJMg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-2.0.3.tgz",
+			"integrity": "sha512-tk/gAgbMMxR6fn1MgMaM1HpU1ryAmBWWitnxG5OhuNXeX0cbpbgV5jA4AIpQJVNoyOfOevTtO6WX+rPs+EFqaQ==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.1",
-				"npm-package-arg": "^8.1.0",
+				"npm-package-arg": "^8.1.2",
 				"promzard": "^0.3.0",
 				"read": "~1.0.1",
-				"read-package-json": "^3.0.0",
-				"semver": "^7.3.2",
+				"read-package-json": "^3.0.1",
+				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4",
 				"validate-npm-package-name": "^3.0.0"
 			},
 			"dependencies": {
 				"normalize-package-data": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-					"integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^3.0.6",
-						"resolve": "^1.17.0",
-						"semver": "^7.3.2",
+						"hosted-git-info": "^4.0.1",
+						"resolve": "^1.20.0",
+						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
 				},
@@ -4100,15 +3738,6 @@
 						"json-parse-even-better-errors": "^2.3.0",
 						"normalize-package-data": "^3.0.0",
 						"npm-normalize-package-bin": "^1.0.0"
-					}
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
 					}
 				}
 			}
@@ -4140,46 +3769,6 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4204,15 +3793,6 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -4266,9 +3846,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
-			"integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -4471,6 +4051,14 @@
 				"@istanbuljs/schema": "^0.1.2",
 				"istanbul-lib-coverage": "^3.0.0",
 				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"istanbul-lib-processinfo": {
@@ -4488,17 +4076,6 @@
 				"uuid": "^3.3.3"
 			},
 			"dependencies": {
-				"cross-spawn": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
 				"make-dir": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4517,44 +4094,11 @@
 						"aggregate-error": "^3.0.0"
 					}
 				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
 				}
 			}
 		},
@@ -4569,12 +4113,6 @@
 				"supports-color": "^7.1.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"make-dir": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4584,14 +4122,11 @@
 						"semver": "^6.0.0"
 					}
 				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -4604,23 +4139,6 @@
 				"debug": "^4.1.1",
 				"istanbul-lib-coverage": "^3.0.0",
 				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"istanbul-reports": {
@@ -4640,9 +4158,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -4692,9 +4210,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
@@ -4803,24 +4321,15 @@
 			},
 			"dependencies": {
 				"normalize-package-data": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-					"integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^3.0.6",
-						"resolve": "^1.17.0",
-						"semver": "^7.3.2",
+						"hosted-git-info": "^4.0.1",
+						"resolve": "^1.20.0",
+						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
 					}
 				}
 			}
@@ -4853,9 +4362,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
 		"lodash._reinterpolate": {
@@ -4874,12 +4383,6 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
 			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
-			"dev": true
-		},
-		"lodash.sortby": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
 		"lodash.template": {
@@ -4973,9 +4476,9 @@
 			}
 		},
 		"map-obj": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-			"integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+			"integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
 			"dev": true
 		},
 		"meow": {
@@ -4998,14 +4501,14 @@
 			},
 			"dependencies": {
 				"normalize-package-data": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-					"integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^3.0.6",
-						"resolve": "^1.17.0",
-						"semver": "^7.3.2",
+						"hosted-git-info": "^4.0.1",
+						"resolve": "^1.20.0",
+						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
 				},
@@ -5022,9 +4525,9 @@
 					},
 					"dependencies": {
 						"hosted-git-info": {
-							"version": "2.8.8",
-							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-							"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+							"version": "2.8.9",
+							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+							"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 							"dev": true
 						},
 						"normalize-package-data": {
@@ -5072,15 +4575,6 @@
 						}
 					}
 				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
 				"type-fest": {
 					"version": "0.18.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
@@ -5102,28 +4596,28 @@
 			"dev": true
 		},
 		"micromatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
 			"dev": true,
 			"requires": {
 				"braces": "^3.0.1",
-				"picomatch": "^2.0.5"
+				"picomatch": "^2.2.3"
 			}
 		},
 		"mime-db": {
-			"version": "1.46.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-			"integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+			"integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.29",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-			"integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+			"version": "2.1.30",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+			"integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.46.0"
+				"mime-db": "1.47.0"
 			}
 		},
 		"mimic-fn": {
@@ -5464,6 +4958,12 @@
 				"process-on-spawn": "^1.0.0"
 			}
 		},
+		"node-releases": {
+			"version": "1.1.71",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+			"dev": true
+		},
 		"nopt": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
@@ -5487,9 +4987,9 @@
 			},
 			"dependencies": {
 				"hosted-git-info": {
-					"version": "2.8.8",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-					"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+					"version": "2.8.9",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+					"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 					"dev": true
 				},
 				"semver": {
@@ -5522,17 +5022,6 @@
 			"dev": true,
 			"requires": {
 				"semver": "^7.1.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"npm-lifecycle": {
@@ -5575,31 +5064,20 @@
 			"dev": true
 		},
 		"npm-package-arg": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.1.tgz",
-			"integrity": "sha512-CsP95FhWQDwNqiYS+Q0mZ7FAEDytDZAkNxQqea6IaAFJTAY9Lhhqyl0irU/6PMc7BGfUmnsbHcqxJD7XuVM/rg==",
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.2.tgz",
+			"integrity": "sha512-6Eem455JsSMJY6Kpd3EyWE+n5hC+g9bSyHr9K9U2zqZb7+02+hObQ2c0+8iDk/mNF+8r1MhY44WypKJAkySIYA==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^3.0.6",
-				"semver": "^7.0.0",
+				"hosted-git-info": "^4.0.1",
+				"semver": "^7.3.4",
 				"validate-npm-package-name": "^3.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"npm-packlist": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-2.1.4.tgz",
-			"integrity": "sha512-Qzg2pvXC9U4I4fLnUrBmcIT4x0woLtUgxUi9eC+Zrcv1Xx5eamytGAfbDWQ67j7xOcQ2VW1I3su9smVTIdu7Hw==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-2.1.5.tgz",
+			"integrity": "sha512-KCfK3Vi2F+PH1klYauoQzg81GQ8/GGjQRKYY6tRnpQUPKTs/1gBZSRWtTEd7jGdSn1LZL7gpAmJT+BcS55k2XQ==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.6",
@@ -5609,25 +5087,15 @@
 			}
 		},
 		"npm-pick-manifest": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-6.1.0.tgz",
-			"integrity": "sha512-ygs4k6f54ZxJXrzT0x34NybRlLeZ4+6nECAIbr2i0foTnijtS1TJiyzpqtuUAJOps/hO0tNDr8fRV5g+BtRlTw==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-6.1.1.tgz",
+			"integrity": "sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==",
 			"dev": true,
 			"requires": {
 				"npm-install-checks": "^4.0.0",
-				"npm-package-arg": "^8.0.0",
-				"semver": "^7.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
+				"npm-normalize-package-bin": "^1.0.1",
+				"npm-package-arg": "^8.1.2",
+				"semver": "^7.3.4"
 			}
 		},
 		"npm-registry-fetch": {
@@ -5735,15 +5203,6 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
 				"cliui": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -5755,51 +5214,11 @@
 						"wrap-ansi": "^6.2.0"
 					}
 				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
 				},
 				"make-dir": {
 					"version": "3.1.0",
@@ -5808,15 +5227,6 @@
 					"dev": true,
 					"requires": {
 						"semver": "^6.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
 					}
 				},
 				"p-map": {
@@ -5828,31 +5238,16 @@
 						"aggregate-error": "^3.0.0"
 					}
 				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
 				},
 				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
@@ -5881,9 +5276,9 @@
 					}
 				},
 				"y18n": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-					"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 					"dev": true
 				},
 				"yargs": {
@@ -5930,9 +5325,9 @@
 			"dev": true
 		},
 		"object-inspect": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-			"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+			"integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
 			"dev": true
 		},
 		"object-keys": {
@@ -6102,9 +5497,9 @@
 			}
 		},
 		"pacote": {
-			"version": "11.2.7",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-11.2.7.tgz",
-			"integrity": "sha512-ogxPor11v/rnU9ukwLlI2dPx22q9iob1+yZyqSwerKsOvBMhU9e+SJHtxY4y2N0MRH4/5jGsGiRLsZeJWyM4dQ==",
+			"version": "11.3.1",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.1.tgz",
+			"integrity": "sha512-TymtwoAG12cczsJIrwI/euOQKtjrQHlD0k0oyt9QSmZGpqa+KdlxKdWR/YUjYizkixaVyztxt/Wsfo8bL3A6Fg==",
 			"dev": true,
 			"requires": {
 				"@npmcli/git": "^2.0.1",
@@ -6224,10 +5619,13 @@
 			},
 			"dependencies": {
 				"qs": {
-					"version": "6.9.6",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-					"integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
-					"dev": true
+					"version": "6.10.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+					"integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+					"dev": true,
+					"requires": {
+						"side-channel": "^1.0.4"
+					}
 				}
 			}
 		},
@@ -6280,9 +5678,9 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+			"integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
 			"dev": true
 		},
 		"pify": {
@@ -6373,12 +5771,6 @@
 			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
-		"puka": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/puka/-/puka-1.0.1.tgz",
-			"integrity": "sha512-ssjRZxBd7BT3dte1RR3VoeT2cT/ODH8x+h0rUF1rMqB0srHYf48stSDWfiYakTp5UBZMxroZhB2+ExLDHm7W3g==",
-			"dev": true
-		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -6410,9 +5802,9 @@
 			}
 		},
 		"queue-microtask": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
-			"integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
 		"quick-lru": {
@@ -6691,12 +6083,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-			"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.0.0",
+				"is-core-module": "^2.2.0",
 				"path-parse": "^1.0.6"
 			}
 		},
@@ -6762,9 +6154,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.6.6",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-			"integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+			"version": "6.6.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -6783,10 +6175,13 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -6829,6 +6224,17 @@
 				"rechoir": "^0.6.2"
 			}
 		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -6854,9 +6260,9 @@
 			"dev": true
 		},
 		"socks": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.5.1.tgz",
-			"integrity": "sha512-oZCsJJxapULAYJaEYBSzMcz8m3jqgGrHaGhkmU/o/PQfFWYWxkAaA0UMGImb6s6tEXfKi959X6VJjMMQ3P6TTQ==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+			"integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
 			"dev": true,
 			"requires": {
 				"ip": "^1.1.5",
@@ -6884,9 +6290,9 @@
 			}
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true
 		},
 		"spawn-wrap": {
@@ -6912,23 +6318,11 @@
 						"semver": "^6.0.0"
 					}
 				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -7132,12 +6526,12 @@
 			}
 		},
 		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "^4.0.0"
 			}
 		},
 		"tar": {
@@ -7190,6 +6584,12 @@
 					"requires": {
 						"semver": "^6.0.0"
 					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -7320,11 +6720,61 @@
 				"tsutils": "^2.29.0"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -7374,9 +6824,9 @@
 			}
 		},
 		"uglify-js": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.0.tgz",
-			"integrity": "sha512-TWYSWa9T2pPN4DIJYbU9oAjQx+5qdV5RUDxwARg8fmJZrD/V27Zj0JngW5xg1DFz42G0uDYl2XhzF6alSzD62w==",
+			"version": "3.13.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
+			"integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
 			"dev": true,
 			"optional": true
 		},
@@ -7393,15 +6843,15 @@
 			"dev": true
 		},
 		"unbox-primitive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
-			"integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.0",
-				"has-symbols": "^1.0.0",
-				"which-boxed-primitive": "^1.0.1"
+				"has-bigints": "^1.0.1",
+				"has-symbols": "^1.0.2",
+				"which-boxed-primitive": "^1.0.2"
 			}
 		},
 		"unique-filename": {
@@ -7516,12 +6966,12 @@
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
-			"integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
+			"integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
+				"lodash": "^4.7.0",
 				"tr46": "^2.0.2",
 				"webidl-conversions": "^6.1.0"
 			}
@@ -7584,30 +7034,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
@@ -7690,6 +7116,12 @@
 						"semver": "^6.0.0"
 					}
 				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
 				"sort-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
@@ -7753,9 +7185,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-			"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"dev": true
 		},
 		"yallist": {
@@ -7765,9 +7197,9 @@
 			"dev": true
 		},
 		"yaml": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
 			"dev": true
 		},
 		"yargs": {
@@ -7820,9 +7252,9 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "20.2.6",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
-			"integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
+			"version": "20.2.7",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+			"integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
 			"dev": true
 		}
 	}

--- a/packages/hooks/deno/compose.ts
+++ b/packages/hooks/deno/compose.ts
@@ -27,7 +27,7 @@ export function compose<T = any> (middleware: Middleware<T>[]) {
 
       index = i;
 
-      let fn = middleware[i];
+      let fn: Middleware|undefined = middleware[i];
 
       if (i === middleware.length) {
         fn = next;

--- a/packages/hooks/deno/hooks.ts
+++ b/packages/hooks/deno/hooks.ts
@@ -2,7 +2,7 @@ import { compose, Middleware } from './compose.ts';
 import {
   HookContext, setManager, HookContextData, HookOptions, convertOptions, setMiddleware
 } from './base.ts';
-import { copyProperties } from './utils.ts';
+import { copyFnProperties, copyProperties } from './utils.ts';
 
 export function getOriginal (fn: any): any {
   return typeof fn.original === 'function' ? getOriginal(fn.original) : fn;
@@ -51,6 +51,7 @@ export function functionHooks <F> (fn: F, managerOrMiddleware: HookOptions) {
     return compose(hookChain).call(this, context);
   };
 
+  copyFnProperties(wrapper, fn);
   copyProperties(wrapper, fn);
   setManager(wrapper, manager);
 

--- a/packages/hooks/deno/index.ts
+++ b/packages/hooks/deno/index.ts
@@ -25,6 +25,7 @@ export type MiddlewareOptions = {
 /**
  * Initializes a hook settings object with the given middleware.
  * @param mw The list of middleware
+ * @param options Middleware options (params, default, props)
  */
 export function middleware (mw?: Middleware[], options?: MiddlewareOptions) {
   const manager = new HookManager().middleware(mw);
@@ -55,7 +56,8 @@ export function middleware (mw?: Middleware[], options?: MiddlewareOptions) {
  * (`middleware([]).params()` etc.)
  */
 export function hooks<F, T = any> (
-  fn: F, manager: HookManager
+    fn: F&(() => void),
+    manager?: HookManager
 ): WrappedFunction<F, T>;
 
 /**
@@ -68,17 +70,17 @@ export function hooks<O> (obj: O|(new (...args: any[]) => O), hookMap: HookMap<O
 
 /**
  * Decorate a class method with hooks.
- * @param _manager The hooks settings
+ * @param manager The hooks settings
  */
 export function hooks<T = any> (
-  _manager?: HookOptions
+  manager?: HookOptions
 ): any;
 
 // Fallthrough to actual implementation
 export function hooks (...args: any[]) {
   const [ target, _hooks ] = args;
 
-  if (typeof target === 'function' && (_hooks instanceof HookManager || Array.isArray(_hooks))) {
+  if (typeof target === 'function' && (_hooks instanceof HookManager || Array.isArray(_hooks) || args.length === 1)) {
     return functionHooks(target, _hooks);
   }
 

--- a/packages/hooks/deno/utils.ts
+++ b/packages/hooks/deno/utils.ts
@@ -37,10 +37,26 @@ export function copyProperties <F> (target: F, ...originals: any[]) {
     for (const prop of originalProps) {
       const propDescriptor = Object.getOwnPropertyDescriptor(original, prop);
 
-      if (!target.hasOwnProperty(prop)) {
+      if (propDescriptor && !Object.prototype.hasOwnProperty.call(target, prop)) {
         Object.defineProperty(target, prop, propDescriptor);
       }
     }
+  }
+
+  return target;
+}
+
+export function copyFnProperties <F> (target: F, original : any) {
+  const internalProps = ['name', 'length'];
+
+  try {
+    for (const prop of internalProps) {
+      const value = original[prop];
+
+      Object.defineProperty(target, prop, { value });
+    }
+  } catch (e) {
+    // Avoid IE error
   }
 
   return target;

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -34,10 +34,10 @@
     "build": "npm run compile && npm run build:browser",
     "compile": "shx rm -rf lib/ && tsc",
     "prepublish": "npm run build",
-    "test:mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts",
-    "test": "npm run build && npm run test:mocha",
+    "mocha": "mocha --config ../../.mocharc.json --recursive test/**.test.ts test/**/*.test.ts",
+    "test": "npm run build && npm run mocha",
     "build:deno": "shx rm -rf deno && shx mkdir -p deno && node build/deno",
-    "test:deno": "npm run build:deno && deno test --config tsconfig.json test/deno_test.ts"
+    "test:deno": "npm run build:deno && deno test test/deno_test.ts"
   },
   "directories": {
     "lib": "lib"
@@ -55,15 +55,15 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.15",
+    "@types/chai": "^4.2.16",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.37",
+    "@types/node": "^14.14.41",
     "mocha": "^8.3.2",
     "shx": "^0.3.3",
-    "ts-loader": "^8.1.0",
+    "ts-loader": "^9.0.1",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.3",
-    "webpack": "^5.28.0",
+    "typescript": "^4.2.4",
+    "webpack": "^5.34.0",
     "webpack-cli": "^4.6.0"
   }
 }

--- a/packages/hooks/src/compose.ts
+++ b/packages/hooks/src/compose.ts
@@ -27,7 +27,7 @@ export function compose<T = any> (middleware: Middleware<T>[]) {
 
       index = i;
 
-      let fn = middleware[i];
+      let fn: Middleware|undefined = middleware[i];
 
       if (i === middleware.length) {
         fn = next;

--- a/packages/hooks/src/utils.ts
+++ b/packages/hooks/src/utils.ts
@@ -37,7 +37,7 @@ export function copyProperties <F> (target: F, ...originals: any[]) {
     for (const prop of originalProps) {
       const propDescriptor = Object.getOwnPropertyDescriptor(original, prop);
 
-      if (!target.hasOwnProperty(prop)) {
+      if (propDescriptor && !Object.prototype.hasOwnProperty.call(target, prop)) {
         Object.defineProperty(target, prop, propDescriptor);
       }
     }

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -5,7 +5,6 @@
   ],
   "compilerOptions": {
     "outDir": "lib",
-    "experimentalDecorators": true,
-    "strictNullChecks": false
+    "experimentalDecorators": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": false,              /* Enable strict null checks. */
+    "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
@@ -32,6 +32,7 @@
     "noUnusedLocals": true,                /* Report errors on unused locals. */
     "noUnusedParameters": true,            /* Report errors on unused parameters. */
     "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "useDefineForClassFields": true,
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */


### PR DESCRIPTION
This is a follow-up to https://github.com/feathersjs/hooks/issues/69. It turns out that Deno 1.9 [set `useDefineForClassFields `](https://deno.com/blog/v1.9#new-default-typescript-option-usedefineforclassfields) which broke checking the result for undefined. This pull request pulls the additional hook context properties into an interface and also enables `strictNullChecks` so that it works with more strict TypeScript settings (including the Deno defaults).