### PR TITLE
fix(hooks): Allow hooks on functions that have properties

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,9 +5,9 @@
       "exclude": []
     },
     "rules": {
-      "tags": [],
+      "tags": ["recommended"],
       "include": [],
-      "exclude": ["no-explicit-any", "require-await"]
+      "exclude": ["no-explicit-any", "require-await", "no-self-assign"]
     }
   },
   "fmt": {

--- a/main/hooks/src/hooks.ts
+++ b/main/hooks/src/hooks.ts
@@ -74,7 +74,7 @@ export function objectHooks(obj: any, hooks: HookMap | AsyncMiddleware[]) {
   }
 
   for (const method of Object.keys(hooks)) {
-    const target = typeof obj[method] === 'function' ? obj : obj.prototype
+    const target = typeof obj[method] === 'function' ? obj : obj.prototype;
     const fn = target && target[method];
 
     if (typeof fn !== 'function') {
@@ -83,9 +83,9 @@ export function objectHooks(obj: any, hooks: HookMap | AsyncMiddleware[]) {
 
     const manager = convertOptions(hooks[method]);
 
-    target[method] = functionHooks(fn, manager.props({ method }));   
+    target[method] = functionHooks(fn, manager.props({ method }));
   }
-  
+
   return obj;
 }
 

--- a/main/hooks/src/utils.ts
+++ b/main/hooks/src/utils.ts
@@ -58,7 +58,7 @@ export function copyFnProperties<F>(target: F, original: any) {
 
       Object.defineProperty(target, prop, { value });
     }
-  } catch (e) {
+  } catch (_e) {
     // Avoid IE error
   }
 

--- a/main/hooks/test/class.test.ts
+++ b/main/hooks/test/class.test.ts
@@ -39,7 +39,7 @@ it('hooking object on class adds to the prototype', async () => {
         await next();
 
         ctx.result += '?';
-      }
+      },
     ]).params('name'),
 
     addOne: middleware([
@@ -47,7 +47,7 @@ it('hooking object on class adds to the prototype', async () => {
         ctx.arguments[0] += 1;
 
         await next();
-      }
+      },
     ]),
   });
 
@@ -58,7 +58,7 @@ it('hooking object on class adds to the prototype', async () => {
 });
 
 it('hooking object works on function that has property', async () => {
-  const app = function () {}
+  const app = function () {};
 
   app.sayHi = (name: string) => `Hello ${name}`;
 
@@ -69,7 +69,7 @@ it('hooking object works on function that has property', async () => {
 
         ctx.result += '?';
       },
-    ]).params('name')
+    ]).params('name'),
   });
 
   assertEquals(await app.sayHi('David'), 'Hello David?');

--- a/main/hooks/test/class.test.ts
+++ b/main/hooks/test/class.test.ts
@@ -39,7 +39,7 @@ it('hooking object on class adds to the prototype', async () => {
         await next();
 
         ctx.result += '?';
-      },
+      }
     ]).params('name'),
 
     addOne: middleware([
@@ -47,7 +47,7 @@ it('hooking object on class adds to the prototype', async () => {
         ctx.arguments[0] += 1;
 
         await next();
-      },
+      }
     ]),
   });
 
@@ -55,6 +55,24 @@ it('hooking object on class adds to the prototype', async () => {
 
   assertEquals(await instance.sayHi('David'), 'Hi David?');
   assertEquals(await instance.addOne(1), 3);
+});
+
+it('hooking object works on function that has property', async () => {
+  const app = function () {}
+
+  app.sayHi = (name: string) => `Hello ${name}`;
+
+  hooks(app as any, {
+    sayHi: middleware([
+      async (ctx: HookContext, next: NextFunction) => {
+        await next();
+
+        ctx.result += '?';
+      },
+    ]).params('name')
+  });
+
+  assertEquals(await app.sayHi('David'), 'Hello David?');
 });
 
 it('works with inheritance', async () => {

--- a/main/hooks/test/compose.test.ts
+++ b/main/hooks/test/compose.test.ts
@@ -182,7 +182,7 @@ it('compose: should catch downstream errors', async () => {
       arr.push(6);
       await next();
       arr.push(7);
-    } catch (err) {
+    } catch (_err) {
       arr.push(2);
     }
     arr.push(3);

--- a/main/hooks/test/decorator.test.ts
+++ b/main/hooks/test/decorator.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertThrows, it } from './dependencies.ts';
+import { assertEquals, assertThrows, it } from './dependencies.ts';
 import { HookContext, hooks, middleware, NextFunction } from '../src/index.ts';
 
 it('hook decorator on method and classes with inheritance', async () => {

--- a/main/hooks/test/object.test.ts
+++ b/main/hooks/test/object.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertStrictEquals, assertThrows, it } from './dependencies.ts';
+import { assertEquals, assertStrictEquals, assertThrows, it } from './dependencies.ts';
 import { HookContext, hooks, middleware, NextFunction } from '../src/index.ts';
 
 interface HookableObject {


### PR DESCRIPTION
This pull request fixes the ability to add object hooks to functions that have a method as a property. Related to https://github.com/feathersjs/feathers/issues/2500#issuecomment-1109801472 and important to e.g. add hooks to an Express application instance (which is a function).