### PR TITLE
fix(hooks): Ensure that all regular error hooks are run

### DIFF
--- a/main/hooks/test/collect.test.ts
+++ b/main/hooks/test/collect.test.ts
@@ -107,6 +107,11 @@ it('collect: error hooks', async () => {
           ctx.result = 'result from error hook';
         }
       },
+      (ctx) => {
+        if (ctx.result === 'result from error hook') {
+          ctx.result += '!';
+        }
+      },
     ],
   });
 
@@ -140,5 +145,5 @@ it('collect: error hooks', async () => {
     'in error hook',
   );
 
-  assertStrictEquals(await service.create('result'), 'result from error hook');
+  assertStrictEquals(await service.create('result'), 'result from error hook!');
 });


### PR DESCRIPTION
This pull request ensures that all regular error hooks are executed. Previously it was returning after the first one (since it returned with an error).