### PR TITLE
fix: restore `context.type`

### DIFF
--- a/main/hooks/src/regular.ts
+++ b/main/hooks/src/regular.ts
@@ -11,10 +11,11 @@ export interface RegularHookMap {
 }
 
 export const runHook = (hook: RegularMiddleware, context: any, type?: string) => {
+  const typeBefore = context.type;
   if (type) context.type = type;
   return Promise.resolve(hook.call(context.self, context))
     .then((res: any) => {
-      if (type) context.type = null;
+      if (type) context.type = typeBefore;
       if (res && res !== context) {
         Object.assign(context, res);
       }


### PR DESCRIPTION
Follow-up of https://github.com/feathersjs/feathers/pull/2890

This restores the `context.type` for regular hooks.